### PR TITLE
Add license and build system metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "icf"
 version = "0.1.0"
 description = "IOBEWI Capsule Format library and CLI"
 authors = [{ name = "IOBEWI" }]
+license = { text = "MPL-2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "cryptography"
@@ -10,3 +11,7 @@ dependencies = [
 
 [project.scripts]
 icf = "icf.cli.icfcli:main"
+
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add project license information in `pyproject.toml`
- configure build system requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_6887a4e886548333952549271f3352b2