### PR TITLE
Update CLI README for dependency installation

### DIFF
--- a/icf/cli/README.md
+++ b/icf/cli/README.md
@@ -91,7 +91,7 @@ Voir le document `SPEC-ICF.md` pour la spécification complète.
 ## 🔐 Dépendances
 
 - Python 3.8+
-- `cryptography` (`pip install cryptography`)
+- Installer les dépendances avec `pip install -r requirements.txt`
 
 ---
 


### PR DESCRIPTION
## Summary
- update the dependency section of the CLI README to instruct users to run `pip install -r requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_6887a5685b3c8333b1c46b4f30a72ac5