### PR TITLE
Add cryptography fallback for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Les tests unitaires peuvent être exécutés avec `pytest` :
 ```bash
 pytest tests
 ```
+
+Si la dépendance [`cryptography`] n'est pas disponible, les tests utilisent
+automatiquement le stub situé dans `tests/cryptography_stub`.


### PR DESCRIPTION
## Summary
- use a small stub when the `cryptography` package is missing
- note stub behaviour in the documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a87cfeec83338757840921a607ea