### PR TITLE
Rename CLI commands

### DIFF
--- a/icf/cli/README.md
+++ b/icf/cli/README.md
@@ -20,8 +20,8 @@ Cette bibliothèque et son interface en ligne de commande permettent de manipule
 
 | Commande        | Description                                               |
 |-----------------|-----------------------------------------------------------|
-| `write`         | Génère une capsule signée à partir d’arguments CLI       |
-| `read`          | Décode et vérifie une capsule `.icf`                      |
+| `encode`        | Génère un binaire `.icf` signé à partir d’arguments CLI   |
+| `decode`        | Décode et vérifie une capsule `.icf`                      |
 | `list-tags`     | Affiche les cycles et matières pédagogiques disponibles   |
 | `export-json`   | Convertit une capsule `.icf` en `.json`                   |
 | `import-json`   | Recharge un `.json`, le signe et produit une `.icf`       |
@@ -33,7 +33,7 @@ Cette bibliothèque et son interface en ligne de commande permettent de manipule
 ### Générer une capsule :
 
 ```bash
-python3 icfcli.py write \
+python3 icfcli.py encode \
   --url https://balabewi.org/audio.mp3 \
   --title "Histoire du soir" \
   --language fr \
@@ -48,7 +48,7 @@ python3 icfcli.py write \
 ### Lire et vérifier une capsule :
 
 ```bash
-python3 icfcli.py read --input sortie.icf --public-key pub.pem
+python3 icfcli.py decode --input sortie.icf --public-key pub.pem
 ```
 
 ### Exporter en JSON :

--- a/icf/cli/icfcli.py
+++ b/icf/cli/icfcli.py
@@ -2,8 +2,8 @@
 icfcli.py – Interface CLI pour le IOBEWI Capsule Format (BCF / ICF)
 
 Permet de :
-- générer une capsule signée (`write`)
-- lire et vérifier une capsule (`read`)
+- générer un binaire copiable sur une puce RFID (`encode`)
+- lire et vérifier une capsule (`decode`)
 - afficher les tags pédagogiques (`list-tags`)
 - exporter une capsule au format JSON (`export-json`)
 - importer et signer une capsule depuis JSON (`import-json`)
@@ -159,26 +159,26 @@ def main():
     parser = argparse.ArgumentParser(description='icf Capsule CLI')
     sub = parser.add_subparsers(dest='cmd', required=True)
 
-    # Commande write
-    write = sub.add_parser('write', help='Encode and sign a capsule')
-    write.add_argument('--url', required=True)
-    write.add_argument('--language')
-    write.add_argument('--title')
-    write.add_argument('--badge-type', type=parse_badge_type,
-                       help='ressource, configuration ou administration')
-    write.add_argument('--retention', type=int)
-    write.add_argument('--tag', help='cycle,subject,sub (ex: 2,6,66)')
-    write.add_argument('--expires', type=int, help='UNIX timestamp')
-    write.add_argument('--private-key', required=True)
-    write.add_argument('--authority-id', required=True, help='8-byte hex (ex: 0123456789ABCDEF)')
-    write.add_argument('--output', required=True, help='Output capsule file')
-    write.set_defaults(func=write_capsule)
+    # Commande encode
+    encode = sub.add_parser('encode', help='Encode and sign a capsule')
+    encode.add_argument('--url', required=True)
+    encode.add_argument('--language')
+    encode.add_argument('--title')
+    encode.add_argument('--badge-type', type=parse_badge_type,
+                        help='ressource, configuration ou administration')
+    encode.add_argument('--retention', type=int)
+    encode.add_argument('--tag', help='cycle,subject,sub (ex: 2,6,66)')
+    encode.add_argument('--expires', type=int, help='UNIX timestamp')
+    encode.add_argument('--private-key', required=True)
+    encode.add_argument('--authority-id', required=True, help='8-byte hex (ex: 0123456789ABCDEF)')
+    encode.add_argument('--output', required=True, help='Output capsule file')
+    encode.set_defaults(func=write_capsule)
 
-    # Commande read
-    read = sub.add_parser('read', help='Decode and verify a capsule')
-    read.add_argument('--input', required=True)
-    read.add_argument('--public-key', help='PEM file to verify signature')
-    read.set_defaults(func=read_capsule)
+    # Commande decode
+    decode = sub.add_parser('decode', help='Decode and verify a capsule')
+    decode.add_argument('--input', required=True)
+    decode.add_argument('--public-key', help='PEM file to verify signature')
+    decode.set_defaults(func=read_capsule)
 
     # Commande list-tags
     list_tag = sub.add_parser('list-tags', help='Liste les cycles et matières pédagogiques disponibles')


### PR DESCRIPTION
## Summary
- rename CLI commands `write` -> `encode` and `read` -> `decode`
- update documentation accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887aba71f4c8333aebd03140f7986ab