### PR TITLE
Implement latest ICF features

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -15,6 +15,7 @@ Cette bibliothèque et son interface en ligne de commande permettent de manipule
 - Export et import JSON
 - Enums intégrés pour les tags pédagogiques (`Cycle`, `Matiere`)
 - Affichage lisible (`tag_str()`)
+- Gestion du champ `system_payload` pour la configuration ou l'administration
 
 ### 🛠️ Interface CLI (`icfcli.py`)
 
@@ -40,6 +41,7 @@ python3 icfcli.py encode  \
   --retention 14 \
   --tag 2,6,42 \
   --expires 1760000000 \
+  --payload '{"volume": 70}' \
   --private-key cle.pem \
   --authority-id 0123456789ABCDEF \
   --output sortie.icf

--- a/cli/icfcli.py
+++ b/cli/icfcli.py
@@ -78,6 +78,13 @@ def encode_icf(args):
             sys.exit(1)
     if args.expires:
         cap.set_expiration(args.expires)
+    if args.payload:
+        p = Path(args.payload)
+        if p.exists():
+            payload_data = p.read_bytes()
+        else:
+            payload_data = args.payload.encode('utf-8')
+        cap.set_system_payload(payload_data)
 
     private_key = load_private_key(args.private_key)
     authority_id = bytes.fromhex(args.authority_id)
@@ -169,6 +176,7 @@ def main():
     encode.add_argument('--retention', type=int)
     encode.add_argument('--tag', help='cycle,subject,sub (ex: 2,6,66)')
     encode.add_argument('--expires', type=int, help='UNIX timestamp')
+    encode.add_argument('--payload', help='JSON string or path for system payload')
     encode.add_argument('--private-key', required=True)
     encode.add_argument('--authority-id', required=True, help='8-byte hex (ex: 0123456789ABCDEF)')
     encode.add_argument('--output', required=True, help='Output capsule file')

--- a/tests/test_icf.py
+++ b/tests/test_icf.py
@@ -95,6 +95,24 @@ def test_badge_type_roundtrip():
     assert decoded.verify(pub)
 
 
+def test_system_payload_roundtrip():
+    priv = OpenSSLPrivateKey()
+    pub = priv.public_key()
+
+    cap = icfCapsule()
+    cap.set_badge_type(BadgeType.CONFIGURATION)
+    cap.set_system_payload(b'{"volume":42}')
+    cap.finalize(priv, b'ABCDEFGH')
+
+    encoded = cap.encode_full()
+    decoded = icfCapsule.decode(encoded)
+
+    assert decoded.get_system_payload() == b'{"volume":42}'
+    d = decoded.to_dict()
+    assert d['system_payload'] == {"volume": 42}
+    assert decoded.verify(pub)
+
+
 def test_cli_list_tags_runs():
     """Ensure the CLI entry point exposes list-tags without import errors."""
     if STUB:


### PR DESCRIPTION
## Summary
- update TLV type codes and add `system_payload`
- support `--payload` when encoding capsules
- document payload field in CLI README
- cover new behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888a7fa48c8333a0511d01f697ee4f